### PR TITLE
Carry information forward

### DIFF
--- a/backend/consts.py
+++ b/backend/consts.py
@@ -1,1 +1,4 @@
 REQUIRED_PAGES = {"Demographics"}
+
+
+ORG_NAME = "orgname"

--- a/backend/logic/manipulate_site_info.py
+++ b/backend/logic/manipulate_site_info.py
@@ -1,6 +1,33 @@
 import logging
 
-from backend.models import db, Site, SiteQuestion, Organization, OrganizationQuestion
+from backend.models import (
+    db,
+    Site,
+    SiteQuestion,
+    Organization,
+    OrganizationQuestion,
+    OrganizationQuestionResponse,
+)
+from backend.consts import ORG_NAME
+
+
+def update_org_and_responses(organization, name):
+    if name:
+        org_question = OrganizationQuestion.query.filter_by(slug=ORG_NAME).first()
+        existing = OrganizationQuestionResponse.query.filter_by(
+            organization_id=organization.id,
+            question_id=org_question.id,
+        ).first()
+        if existing:
+            existing.value = name
+            db.session.add(existing)
+        else:
+            new_response = OrganizationQuestionResponse(
+                organization_id=organization.id, question_id=org_question.id, value=name
+            )
+            db.session.add(new_response)
+            organization.question_responses.append(new_response)
+    db.session.commit()
 
 
 def create_or_update_site_from_responses(user, responses_data):

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -37,6 +37,7 @@ from backend.utils.jwt_utils import generate_jwt_payload, get_current_user, JWTE
 from backend.logic.manipulate_site_info import (
     create_or_update_site_from_responses,
     create_or_update_org_from_responses,
+    update_org_and_responses,
 )
 
 api_bp = Blueprint("api", __name__)
@@ -224,9 +225,9 @@ def register():
     org_name = data.get("orgName")
     password = data.get("password")
 
-    site = Organization.query.filter_by(name=org_name).first()
+    org = Organization.query.filter_by(name=org_name).first()
     # there shouldn't be an existing site with the same name
-    if site:
+    if org:
         return (
             jsonify(
                 {
@@ -246,6 +247,8 @@ def register():
         org = Organization(name=org_name)
         db.session.add(org)
         db.session.commit()
+        org = Organization.query.filter_by(name=org_name).first()
+        update_org_and_responses(org, org_name)
 
         # Hash the password before storing it
         hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())

--- a/src/app/create-account/page.tsx
+++ b/src/app/create-account/page.tsx
@@ -1,52 +1,92 @@
 "use client";
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { signIn } from "next-auth/react";
 import ActionButton from "@/components/ui/ActionButton";
 import ErrorAlert from "@/components/ui/ErrorAlert";
+import { colors } from "@/styles/colors";
 
 export default function CreateAccountPage() {
-  const [email, setEmail] = useState("");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const initialEmail = searchParams.get("email") || "";
+  const [email, setEmail] = useState(initialEmail);
   const [password, setPassword] = useState("");
   const [orgName, setOrgName] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (initialEmail && !orgName) {
+      const namePart = initialEmail.split("@")[0];
+      const formatted = namePart
+        .replace(/[.\-_]/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+      setOrgName(formatted);
+    }
+  }, [initialEmail, orgName]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
-    // front-end validation
     if (!email || !password || !orgName) {
       setError("Please fill out all fields.");
       return;
     }
 
     try {
+      setLoading(true);
+
       const res = await fetch(`/flask-api/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ orgName, email, password }),
       });
+
       const data = await res.json();
 
       if (res.ok) {
-        router.push("/login");
+        // After successful registration, automatically sign them in
+        const signInResult = await signIn("credentials", {
+          redirect: false,
+          email,
+          password,
+        });
+
+        if (signInResult?.ok) {
+          router.push("/");
+        } else {
+          setError(
+            "Account created, but failed to log in. Please log in manually.",
+          );
+          router.push("/login"); // Fallback
+        }
       } else {
         setError(data.error || "Registration failed. Please try again.");
       }
     } catch (err) {
       console.error("Registration error:", err);
       setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
-    <div className="flex justify-center items-center h-screen bg-gray-100">
+    <div
+      className="flex justify-center items-center h-screen"
+      style={{ backgroundColor: colors.secondary.base }}
+    >
       <form
         onSubmit={handleSubmit}
         className="bg-white p-8 rounded-lg shadow-md w-96 space-y-6"
       >
-        <h2 className="text-2xl font-bold text-center">Create Account</h2>
+        <h2 className="text-2xl font-bold text-center text-blue-900">
+          Create Account
+        </h2>
 
         <div>
           <label className="block text-gray-700 mb-1">Organization Name</label>
@@ -55,6 +95,7 @@ export default function CreateAccountPage() {
             value={orgName}
             onChange={(e) => setOrgName(e.target.value)}
             className="w-full px-3 py-2 border rounded-lg"
+            placeholder="Your Organization"
             required
           />
         </div>
@@ -66,6 +107,7 @@ export default function CreateAccountPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full px-3 py-2 border rounded-lg"
+            placeholder="you@example.com"
             required
           />
         </div>
@@ -77,14 +119,19 @@ export default function CreateAccountPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="w-full px-3 py-2 border rounded-lg"
+            placeholder="Create a password"
             required
           />
         </div>
 
-        {/* error message */}
         {error && <ErrorAlert message={error} />}
 
-        <ActionButton type="submit" label="Create Account" variant="primary" />
+        <ActionButton
+          type="submit"
+          label={loading ? "Creating..." : "Create Account"}
+          variant="primary"
+          disabled={loading}
+        />
       </form>
     </div>
   );


### PR DESCRIPTION
When a user creates a new account, instead of having to type their email three times - once at the begining, once during signup, and once during login - they just have to type it one time. When they make a new account with a new organization, the UI will remember the organization name moving forward